### PR TITLE
Add Contributing file

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -1,0 +1,94 @@
+# Orphan Support (Web App)
+
+---
+
+![GitHub custom open for collaboration](https://img.shields.io/badge/Open%20For-Collaboration-brightgreen?style=for-the-badge)
+
+🎉 First off, thanks for taking the time out of your schedule and deciding to contribute here! 👍
+
+This repository is open for all contributions, and is accepting contributions under under [AOS 2020 (Autumn of Open Source)](http://aos.sanscript.tech/) by [Sanscript, India](https://sanscript.tech/). Any kind of updation, addition, modification and other valuable contributions are welcome.
+
+In case you're new to open source and contributing, be sure to read about [GitHub](https://guides.github.com/activities/hello-world/#:~:text=GitHub%20is%20a%20code%20hosting,%2C%20commits%2C%20and%20Pull%20Requests.), [GitHub Guide](https://guides.github.com/), [GitHub Open Source](https://github.com/open-source), and you are encouraged to check [OpenSource.Guide](http://opensource.guide/).
+
+Please feel free to open new issues and pull requests, wherever needed.
+
+Every contribution counts, and will go a long way towards betterment of the code and/or its related files.
+
+### Assistance to get started
+
+If you're new to contributing and have no idea about working with repositories, be sure to check and [start here](https://github.com/firstcontributions/first-contributions). [GitHub docs to getting started](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github) from GitHub may also be helpful to refer.
+
+### Steps to Contribute in GitHub Repository
+
+To be able to contribute to this repository, be sure to fork this repository from the fork option at the top-right of [this repository](https://github.com/sanscript-tech/orphan_support-php), if not yet done. Your forked repository is from where you'll initiate (and later update, if needed) your pull requests from.
+
+Go to your forked repository to add and update files for improvisation. 
+Now, you can do this either directly from [GitHub Website](https://github.com), or by using [GitHub CLI](https://github.com/cli/cli) ([Command Line Interface](https://docs.github.com/en/github/getting-started-with-github/set-up-git)). For a better control over the contents of your forked repo, [GitHub CLI]((https://docs.github.com/en/github/getting-started-with-github/set-up-git)) is suggested.
+
+After cloning the repository, please read and understand what the existing code or document is meant for, before overwriting it with your changes. If you're unsure about any part, feel free to ask it in discussions, and we'd be happy to help.
+
+#### Essential Guidelines for contribution against Autumn of Open Source 2020:
+
+Before you start off with the contribution, 
+
+:bulb: Be sure to look into, and adhere to these points: 
+
+* First comment on the opened issues on which you want to work as "Can I take up the work ?", "I would like to work on this!", etc. :loudspeaker:
+
+* Wait for approval. After it's assigned to you then move on further, fork the repository and clone it (if haven't yet done) and start your work according to the guidelines given in the [README.md](https://github.com/sanscript-tech/orphan_support-php/blob/main/README.md) of repository.
+
+#### More Contribution Guidelines :guard:
+
+ 1. Issues will be assigned on a first come first serve basis.
+ 2. Maximum two active issues can be assigned to a single individual.
+ 3. Mention the essential details, like programmming language you want to work in, while asking for issues.
+ 4. Make a separate branch for each issue, and use appropriate branch names for the same.
+ 5. Write clean and easy to understand code. Avoid copy pasting code, we're strictly against plagiarism! 
+ 6. Provide comments wherever necessary.
+ 7. Add a README.md to the folders included, explaining the working of the script.
+ 8. Add an appropriate screenshot of output or demo in the README.
+ 9. Add a "requirements.txt" file that enlists the program requirements, in case dependencies are required.
+10. Perform a self-review before submitting the PR and wait for the mentors to review it and merge.
+
+:ribbon: **Please go through the following essential steps for successfully submitting a PR (Pull Request) here:** :rocket:
+
+1. Star (Optional, will help you stay up-to-date about the later changes in the base repository) and Fork this repository. :checkered_flag:
+
+2. Clone it :globe_with_meridians: using command `git clone <Your_Forked_Repo_URL_Here>` in your CLI. This will download and save a folder for your existing repository, locally in your machine.
+
+3. Switch to a branch using `git checkout -b <branchName>`, in which you are required to work (usually it is 'main' or 'master', but for our cases, it'll be "dev_username". In place of username, mention your GitHub username). Remember, do not directly checkout from 'master' branch of your forked repository.
+
+4. Check existing files, and make your desired updations.
+
+5. Open a command prompt/terminal in the same directory and enter `git add .` or `git add -A`. This adds all the files for tracking and will be including them in the next commit.
+
+6. Commit your changes with `git commit -m "<Your One-Liner Commit Message>"`. In place of message, put a valuable and meaningful message so that it is easier for us to understand the changes you have done. This commits your changes locally.
+
+7. Use `git pull -u` or `git pull --set-upstream origin <branchName>` (The `-u` or `--set-upstream` flag only needs to be used in the first time. For later use, `git pull` can be used without any additional flags). This pulls any further changes from the server and ensures that the local branch is again up-to-date with the remote server. 
+
+8. Push your changes to remote server using `git push` or `git push origin <branchName>`. This pushes your changes to the repository.
+
+After following these steps in Git CLI (in order), you'll need to go to your GitHub repository in the website to initiate a new Pull Request. Now create a pull request by comparing 'dev_username' branch of your forked repository with 'master' branch of this upstream repository. :confetti_ball:
+
+:trophy: After this, project leaders and mentors will review the changes and will merge your PR if they are found good, otherwise we will suggest the required changes.
+
+### Style Guides for Git Commit Messages
+
+Here's a list of some good to have points, that can add more value to your contribution logs.
+
+- Use the present tense (example: "Add feature" and not "Added feature")
+- Use the imperative mood (example: "Move item to...", instead of "Moves item to...")
+- Limit the first line (also called subject line) to 50 characters or less
+- Capitalize the subject line
+- Separate subject from body with a blank line
+- Do not end the subject line with a period
+- Wrap the body at 72 characters
+- Use the body to explain what and why vs. how
+- Reference issues and pull requests liberally after the first line
+
+For more detailed reference to the above points, refer here: [https://chris.beams.io/posts/git-commit/].
+
+
+So, what are you waiting for? Begin contributing now! :fire: :rocket:
+
+All the Best! 🥇


### PR DESCRIPTION
This commit adds a contributing.md file that could be referred to by contributors, related to contributions to be initiated in the repository and steps and guidelines in order to make a valid contribution. 
This PR fixes #3.

Moderators, please have a look at the [rich Contributing Markdown file](https://github.com/sanscript-tech/orphan_support-php/pull/11/files?short_path=1246fce#diff-1246fcebc419eba2aaf5b810ef51db6ec5606f34da054746e1b31bdd7378405d) added, and let me know if any updations are required, or merge it, if it is alright.